### PR TITLE
Update iSpindel.cpp

### DIFF
--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -696,7 +696,7 @@ bool uploadData(uint8_t service)
     sender.add("1", String(Tilt, 1)+"°");
     sender.add("2", tempToSend);
     sender.add("3", voltToSend+"V");
-    sender.add("4", String(Gravity, 2));
+    sender.add("4", String(Gravity, 3));
     return sender.sendBlynk(my_token);
   }
 #endif


### PR DESCRIPTION
The problem happens when data are sending to Blynk and using the specific gravity.

The specific gravity value is rounded only two digits after the decimal point, which takes away from the precision.
for example :

    specific gravity read by the iSpindel: 1.052
    specific gravity sent to blynk: 1.05
